### PR TITLE
Feat/fetch data dynamically

### DIFF
--- a/lib/opendata-tw.js
+++ b/lib/opendata-tw.js
@@ -24,9 +24,6 @@ class OpendataTW {
 	}
 };
 
-OpendataTW.urlFirst1000 = 'https://data.taipei/api/v1/dataset/b0011e96-3fc3-43ec-8bf5-07fb46dd22bb?scope=resourceAquire&q=&limit=1000=&offset=0';
-OpendataTW.urlSecond1000 = 'https://data.taipei/api/v1/dataset/b0011e96-3fc3-43ec-8bf5-07fb46dd22bb?scope=resourceAquire&q=&limit=1000=&offset=1000';
-
 function requestData(offset = 0, limit = 1000) {
 	return request(
 		`https://data.taipei/api/v1/dataset/b0011e96-3fc3-43ec-8bf5-07fb46dd22bb?scope=resourceAquire&q=&limit=${limit}=&offset=${offset}`

--- a/lib/opendata-tw.js
+++ b/lib/opendata-tw.js
@@ -1,3 +1,5 @@
+const request = require('request-promise');
+
 const getDateHash = function (dateStr) {
 	return Math.floor(new Date(dateStr).getTime() / 86400 / 1000);
 };
@@ -22,8 +24,15 @@ class OpendataTW {
 	}
 };
 
-// TODO: fetch method rather than url
 OpendataTW.urlFirst1000 = 'https://data.taipei/api/v1/dataset/b0011e96-3fc3-43ec-8bf5-07fb46dd22bb?scope=resourceAquire&q=&limit=1000=&offset=0';
 OpendataTW.urlSecond1000 = 'https://data.taipei/api/v1/dataset/b0011e96-3fc3-43ec-8bf5-07fb46dd22bb?scope=resourceAquire&q=&limit=1000=&offset=1000';
 
+function requestData(offset = 0, limit = 1000) {
+	return request(
+		`https://data.taipei/api/v1/dataset/b0011e96-3fc3-43ec-8bf5-07fb46dd22bb?scope=resourceAquire&q=&limit=${limit}=&offset=${offset}`
+	);
+}
+
 module.exports = OpendataTW;
+
+module.exports.requestData = requestData;

--- a/lib/taiwan-holiday.js
+++ b/lib/taiwan-holiday.js
@@ -2,7 +2,6 @@ const env_conf = require('./config');
 const Cache = require('./cache');
 const OpendataTW = require('./opendata-tw');
 
-const request = require('request-promise');
 const path = require('path');
 
 var engine;
@@ -17,20 +16,46 @@ var TaiwanHoliday = {
 		temp_dir = ctor_conf.temp_dir || env_conf.temp_dir;
 
 		this.cache = new Cache(path.resolve(temp_dir, 'taiwan-holiday-cache.json'));
-		return this.cache.load()
-			.catch(() => {
-				return Promise.all([request(OpendataTW.urlFirst1000), request(OpendataTW.urlSecond1000)])
-					.then(results => results.reduce((result, currentResult) => {
-						let json = JSON.parse(currentResult)
-						return result.concat(json.result.results)
-					}, []))
-					.then((result) => {
-						this.cache.save(result);
-						return result;
-					});
-			}).then((json) => {
-				engine = new OpendataTW(json);
-			}).catch((e) => {
+		return this.cache
+			.load()
+			.catch(() =>
+				OpendataTW.requestData(0, 1000)
+					.then((result) => JSON.parse(result))
+					.then((json) => {
+						resultNumber = json.result.count;
+						let firstResults = json.result.results;
+						// if the result number is more then the first fetch, more fetches are needed to merge all results
+						// Create requests
+						console.log(`resultNumber is ${resultNumber}`);
+						console.log([
+							...new Array(Math.ceil(resultNumber / 1000) - 1).keys(),
+						]);
+						const offsets = [
+							...new Array(Math.ceil(resultNumber / 1000) - 1).keys(),
+						].map((v) => (v + 1) * 1000);
+						console.log(`offsets is ${offsets}`);
+						return Promise.all(
+							[Promise.resolve(firstResults)].concat(
+								offsets.map((offset) =>
+									OpendataTW.requestData(offset, 1000).then(
+										(response) => JSON.parse(response).result.results
+									)
+								)
+							)
+						);
+					})
+					.then((results) => {
+						json = results.reduce((accumulator, currentValue) => {
+							return accumulator.concat(currentValue);
+						}, []);
+						engine = new OpendataTW(json);
+						return json;
+					})
+					.then((json) => {
+						return this.cache.save(json);
+					})
+			)
+			.catch((e) => {
 				console.error(e);
 				throw e;
 			});
@@ -42,7 +67,7 @@ var TaiwanHoliday = {
 		}
 
 		return engine.isHoliday(date);
-	}
+	},
 };
 
 module.exports = TaiwanHoliday;

--- a/lib/taiwan-holiday.js
+++ b/lib/taiwan-holiday.js
@@ -26,14 +26,9 @@ var TaiwanHoliday = {
 						let firstResults = json.result.results;
 						// if the result number is more then the first fetch, more fetches are needed to merge all results
 						// Create requests
-						console.log(`resultNumber is ${resultNumber}`);
-						console.log([
-							...new Array(Math.ceil(resultNumber / 1000) - 1).keys(),
-						]);
 						const offsets = [
 							...new Array(Math.ceil(resultNumber / 1000) - 1).keys(),
 						].map((v) => (v + 1) * 1000);
-						console.log(`offsets is ${offsets}`);
 						return Promise.all(
 							[Promise.resolve(firstResults)].concat(
 								offsets.map((offset) =>

--- a/lib/taiwan-holiday.js
+++ b/lib/taiwan-holiday.js
@@ -62,7 +62,7 @@ var TaiwanHoliday = {
 		}
 
 		return engine.isHoliday(date);
-	},
+	}
 };
 
 module.exports = TaiwanHoliday;


### PR DESCRIPTION
This PR aims to solve #9.

Once the PR is merged, `TaiwanHoliday.init` will fetch the first 1000 results and fetch the remaining data based on result.count in the response of first 1000 results.

A new function, `requestData` is added to `lib/opendata-tw.js` to support the operations.

The hard-coded URLs in `OpendataTW` are considered deprecated because of the new operation. Hence they are removed in this PR.